### PR TITLE
24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -389,9 +389,10 @@
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-stable": {
@@ -404,9 +405,10 @@
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-24.05",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "openwrt-imagebuilder": {

--- a/flake.lock
+++ b/flake.lock
@@ -409,22 +409,6 @@
         "type": "indirect"
       }
     },
-    "nu-scripts": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1717097863,
-        "narHash": "sha256-dkOiAwWImleVWzJ+JxrVxlchlG8F2bPEFykGQ8W2wCc=",
-        "owner": "nushell",
-        "repo": "nu_scripts",
-        "rev": "e4dbec663beae2c27a2e1e084514bb9a3f08c861",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nushell",
-        "repo": "nu_scripts",
-        "type": "github"
-      }
-    },
     "openwrt-imagebuilder": {
       "inputs": {
         "nixpkgs": [
@@ -463,7 +447,6 @@
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs",
         "nixpkgs-stable": "nixpkgs-stable",
-        "nu-scripts": "nu-scripts",
         "openwrt-imagebuilder": "openwrt-imagebuilder",
         "teawiebot": "teawiebot",
         "terranix": "terranix"

--- a/flake.lock
+++ b/flake.lock
@@ -396,16 +396,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1716991068,
-        "narHash": "sha256-Av0UWCCiIGJxsZ6TFc+OiKCJNqwoxMNVYDBChmhjNpo=",
+        "lastModified": 1717144377,
+        "narHash": "sha256-F/TKWETwB5RaR8owkPPi+SPJh83AQsm6KrQAlJ8v/uA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25cf937a30bf0801447f6bf544fc7486c6309234",
+        "rev": "805a384895c696f802a9bf5bf4720f37385df547",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -125,11 +125,6 @@
       };
     };
 
-    nu-scripts = {
-      url = "github:nushell/nu_scripts";
-      flake = false;
-    };
-
     openwrt-imagebuilder = {
       url = "github:astro/nix-openwrt-imagebuilder";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "nixpkgs/nixos-23.11";
+    nixpkgs-stable.url = "nixpkgs/nixos-24.05";
     nix-darwin = {
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -37,8 +37,8 @@
     };
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
     nix-darwin = {
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/nixos/desktop/plasma/default.nix
+++ b/modules/nixos/desktop/plasma/default.nix
@@ -9,34 +9,31 @@
 in {
   options.desktop.plasma.enable = lib.mkEnableOption "Plasma desktop";
 
-  config = lib.mkIf cfg.enable (
-    # this is bad, i don't care
-    lib.optionalAttrs (lib.versionAtLeast lib.version "24.05pre-git") {
-      environment = {
-        plasma6.excludePackages = with pkgs.kdePackages; [
-          khelpcenter
-          plasma-browser-integration
-          print-manager
-        ];
+  config = lib.mkIf cfg.enable {
+    environment = {
+      plasma6.excludePackages = with pkgs.kdePackages; [
+        khelpcenter
+        plasma-browser-integration
+        print-manager
+      ];
 
-        sessionVariables = {
-          NIXOS_OZONE_WL = "1";
-        };
-
-        systemPackages = [
-          pkgs.haruna
-          inputs.krunner-nix.packages.${pkgs.system}.default
-        ];
+      sessionVariables = {
+        NIXOS_OZONE_WL = "1";
       };
 
-      services.xserver = {
-        displayManager.sddm = {
-          enable = true;
-          wayland.enable = true;
-        };
+      systemPackages = [
+        pkgs.haruna
+        inputs.krunner-nix.packages.${pkgs.system}.default
+      ];
+    };
 
-        desktopManager.plasma6.enable = true;
+    services = {
+      displayManager.sddm = {
+        enable = true;
+        wayland.enable = true;
       };
-    }
-  );
+
+      desktopManager.plasma6.enable = true;
+    };
+  };
 }

--- a/users/seth/desktop/plasma/default.nix
+++ b/users/seth/desktop/plasma/default.nix
@@ -4,7 +4,7 @@
   osConfig,
   ...
 }: let
-  enable = osConfig.services.xserver.desktopManager.plasma6.enable or false;
+  enable = osConfig.services.desktopManager.plasma6.enable or false;
 in {
   config = lib.mkIf enable {
     home.packages = with pkgs; [

--- a/users/seth/shell/nu.nix
+++ b/users/seth/shell/nu.nix
@@ -1,7 +1,7 @@
 {
   config,
   lib,
-  inputs,
+  pkgs,
   ...
 }: let
   cfg = config.seth.shell.nushell;
@@ -23,7 +23,7 @@ in {
         '';
 
         envFile.text = ''
-          use ${inputs.nu-scripts}/themes/nu-themes/${theme}.nu
+          use ${pkgs.nu_scripts}/share/nu_scripts/themes/nu-themes/${theme}.nu
           $env.config.color_config = (${theme})
         '';
 


### PR DESCRIPTION
- **flake: nixpkgs-stable 23.11 -> 24.05**
- **modules: support >= 24.05**
- **flake: update home-manager**
- **seth: use nixpkgs' `nu_scripts`**
- **flake: don't depend on registry for nixpkgs inputs**
