### PR TITLE
flake: update all inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,17 +8,17 @@
           "nixpkgs"
         ],
         "systems": [
-          "lanzaboote",
+          "nixos-wsl",
           "flake-utils",
           "systems"
         ]
       },
       "locked": {
-        "lastModified": 1720546205,
-        "narHash": "sha256-boCXsjYVxDviyzoEyAk624600f3ZBo/DKtUdvMTpbGY=",
+        "lastModified": 1722339003,
+        "narHash": "sha256-ZeS51uJI30ehNkcZ4uKqT4ZDARPyqrHADSKAwv5vVCU=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "de96bd907d5fbc3b14fc33ad37d1b9a3cb15edc6",
+        "rev": "3f1dae074a12feb7327b4bf43cbac0d124488bb7",
         "type": "github"
       },
       "original": {
@@ -31,7 +31,7 @@
       "inputs": {
         "flake-compat": [],
         "flake-utils": [
-          "lanzaboote",
+          "nixos-wsl",
           "flake-utils"
         ],
         "nixpkgs": [
@@ -40,11 +40,11 @@
         "pre-commit": []
       },
       "locked": {
-        "lastModified": 1718613978,
-        "narHash": "sha256-iXzxAcovEZHHYUYIWtIJYMpQf96MwasMirMxMKJL5Aw=",
+        "lastModified": 1721720317,
+        "narHash": "sha256-KH0ILX8EGa/A4Bgc6DtsbviG8qaLrzDDV1m1bIXJ+pw=",
         "owner": "dwarfmaster",
         "repo": "arkenfox-nixos",
-        "rev": "35e803fa44abfd438c65b64ff2691f3f608cd2d3",
+        "rev": "92c9a287b7b98198c3ba5cdfc90218402e49c4b3",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1720472194,
-        "narHash": "sha256-CYscFEts6tyvosc1T29nxhzIYJAj/1CCEkV3ZMzSN/c=",
+        "lastModified": 1722661201,
+        "narHash": "sha256-2JX3S1hmmUhHuyGyGWnaM4xT0SiaDdVkNzmBrEowwK0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d75d5803852fb0833767dc969a4581ac13204e22",
+        "rev": "19a0f144f0204a12a89243363efb6a493b8cfc83",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718474113,
-        "narHash": "sha256-UKrfy/46YF2TRnxTtKCYzqf2f5ZPRRWwKCCJb7O5X8U=",
+        "lastModified": 1721842668,
+        "narHash": "sha256-k3oiD2z2AAwBFLa4+xfU+7G5fisRXfkvrMTCJrjZzXo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0095fd8ea00ae0a9e6014f39c375e40c2fbd3386",
+        "rev": "529c1a0b1f29f0d78fa3086b8f6a134c71ef3aaf",
         "type": "github"
       },
       "original": {
@@ -92,7 +92,7 @@
     "firefox-addons": {
       "inputs": {
         "flake-utils": [
-          "lanzaboote",
+          "nixos-wsl",
           "flake-utils"
         ],
         "nixpkgs": [
@@ -101,11 +101,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1719875691,
-        "narHash": "sha256-DtfpH7yivPHcfXV0EL70NwCKlg6nVTZGNngWkPshQjM=",
+        "lastModified": 1721458684,
+        "narHash": "sha256-qATZkwG7oWObKqAJUJh1jj5KwTYcPUjLoONhXXXwgAY=",
         "owner": "~rycee",
         "repo": "nur-expressions",
-        "rev": "f2c6c0e41d6c2c82524b9d104bcfd1750a426d1b",
+        "rev": "9cb92b3f92598f77aa8b95b54e5d72ad23745d64",
         "type": "sourcehut"
       },
       "original": {
@@ -122,11 +122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721183095,
-        "narHash": "sha256-ySi8kE7mQLF38HeAFxNGRgdpK9SMh/GAtZpwdYRLyUQ=",
+        "lastModified": 1722647263,
+        "narHash": "sha256-4TwY0sXTElpOrHlcgnzU29x+OFFy0NOEbnSJVa3V7Ig=",
         "owner": "getchoo",
         "repo": "getchvim",
-        "rev": "b19001b3f3cf004c3e1fe3021580ed5368849502",
+        "rev": "c120e1df24f1e44a6f7c8a9e16ac8269648501bd",
         "type": "github"
       },
       "original": {
@@ -180,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721135958,
-        "narHash": "sha256-H548rpPMsn25LDKn1PCFmPxmWlClJJGnvdzImHkqjuY=",
+        "lastModified": 1722630065,
+        "narHash": "sha256-QfM/9BMRkCmgWzrPDK+KbgJOUlSJnfX4OvsUupEUZvA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afd2021bedff2de92dfce0e257a3d03ae65c603d",
+        "rev": "afc892db74d65042031a093adb6010c4c3378422",
         "type": "github"
       },
       "original": {
@@ -220,7 +220,6 @@
         "flake-parts": [
           "flake-parts"
         ],
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -228,11 +227,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1719818887,
-        "narHash": "sha256-Bogl1pJlgby7OpR16jp8zwOWV7FHRxCsnNxHcisyIq0=",
+        "lastModified": 1722329086,
+        "narHash": "sha256-e/fSi0WER06N8WCvpht62fkGtWfe5ckDxr6zNYkwkFw=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0e6457c98547ec8866714d4222545e7e8c1ae429",
+        "rev": "f5a3a7dff44d131807fc1a89fbd8576cd870334a",
         "type": "github"
       },
       "original": {
@@ -248,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721270582,
-        "narHash": "sha256-MdZmYPPExntE5rJu88IhJSy8Um4UyZCTXhOwvzbjDVI=",
+        "lastModified": 1722609272,
+        "narHash": "sha256-Kkb+ULEHVmk07AX+OhwyofFxBDpw+2WvsXguUS2m6e4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a3e4a7b8ffc08c7dc1973822a77ad432e1ec3dec",
+        "rev": "f7142b8024d6b70c66fd646e1d099d3aa5bfec49",
         "type": "github"
       },
       "original": {
@@ -268,11 +267,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720926593,
-        "narHash": "sha256-fW6e27L6qY6s+TxInwrS2EXZZfhMAlaNqT0sWS49qMA=",
+        "lastModified": 1722740924,
+        "narHash": "sha256-UQPgA5d8azLZuDHZMPmvDszhuKF1Ek89SrTRtqsQ4Ss=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "5fe5b0cdf1268112dc96319388819b46dc051ef4",
+        "rev": "97ca0a0fca0391de835f57e44f369a283e37890f",
         "type": "github"
       },
       "original": {
@@ -304,20 +303,17 @@
     "nixos-wsl": {
       "inputs": {
         "flake-compat": [],
-        "flake-utils": [
-          "lanzaboote",
-          "flake-utils"
-        ],
+        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1721226275,
-        "narHash": "sha256-fwTSeMR1senkBPaKQyOkbkmFu3+8jj3UHoLZ3TcrOfw=",
+        "lastModified": 1722253092,
+        "narHash": "sha256-37vyqHPx57deHhwvi4jwyNQLYkhm/rlVTYKOG1iahsc=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "8ebede998342477736e0d0acdcc13ddb166a335f",
+        "rev": "f373ad59ae5866f0f98216bd5c71526b373450d2",
         "type": "github"
       },
       "original": {
@@ -367,11 +363,11 @@
         "treefmt-nix": []
       },
       "locked": {
-        "lastModified": 1721074995,
-        "narHash": "sha256-WQWoC7mgNBiau7o8DVAO2jC3nBkPZXJnE1u39UI2BF0=",
+        "lastModified": 1722678577,
+        "narHash": "sha256-kVLQ/SCQK6n9ZrCvPqBqEKa+zJp15jdCqMdMycIueow=",
         "owner": "getchoo",
         "repo": "nixpkgs-tracker-bot",
-        "rev": "9b0e19d603e35083fa4ffefb1aedf13d8cfa8501",
+        "rev": "04af0af364a2c6ecabd2340a422049ec984357f4",
         "type": "github"
       },
       "original": {
@@ -387,11 +383,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721378452,
-        "narHash": "sha256-QfNNGQ9QQ1N7oVE8+LVqcQoENBapkU86eS5ULTIfNWc=",
+        "lastModified": 1722761384,
+        "narHash": "sha256-yWPtbkhguI/BJtf+PWKKAYLSi2yuNlB25uA/NNjG4Bc=",
         "owner": "astro",
         "repo": "nix-openwrt-imagebuilder",
-        "rev": "10a88c589e32e04dd717d5588b5ebacf83f25629",
+        "rev": "02f547ee5f2e70488d643938903072590cb7fa86",
         "type": "github"
       },
       "original": {
@@ -426,21 +422,17 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "lanzaboote",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "lanzaboote",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1718504420,
-        "narHash": "sha256-F2HT/abCfr0CDpkvXwYCscJyD66XDTLMVfdrIMRp2ck=",
+        "lastModified": 1722219664,
+        "narHash": "sha256-xMOJ+HW4yj6e69PvieohUJ3dBSdgCfvI0nnCEe6/yVc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0043c3f92304823cc2c0a4354b0feaa61dfb4cd9",
+        "rev": "a6fbda5d9a14fb5f7c69b8489d24afeb349c7bb4",
         "type": "github"
       },
       "original": {
@@ -472,11 +464,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720833990,
-        "narHash": "sha256-OMIkhlYRgNciEFuDi7iGu7excf5/F3Wli2XPpQraqRs=",
+        "lastModified": 1722043293,
+        "narHash": "sha256-zDLfFk21J7Q+s6XZrotncqOao9vyMQN8dqOahqEeWkM=",
         "owner": "getchoo",
         "repo": "teawiebot",
-        "rev": "5337f7eb3f8554b712a229de488937c01000db2d",
+        "rev": "372780546b508684839916e5ad54c9e90456a94f",
         "type": "github"
       },
       "original": {
@@ -490,7 +482,7 @@
         "bats-assert": [],
         "bats-support": [],
         "flake-utils": [
-          "lanzaboote",
+          "nixos-wsl",
           "flake-utils"
         ],
         "nixpkgs": [
@@ -519,11 +511,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721382922,
-        "narHash": "sha256-GYpibTC0YYKRpFR9aftym9jjRdUk67ejw1IWiaQkaiU=",
+        "lastModified": 1722330636,
+        "narHash": "sha256-uru7JzOa33YlSRwf9sfXpJG+UAV+bnBEYMjrzKrQZFw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "50104496fb55c9140501ea80d183f3223d13ff65",
+        "rev": "768acdb06968e53aa1ee8de207fd955335c754b7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
         nixpkgs.follows = "nixpkgs";
         darwin.follows = "";
         home-manager.follows = "";
-        systems.follows = "lanzaboote/flake-utils/systems";
+        systems.follows = "nixos-wsl/flake-utils/systems";
       };
     };
 
@@ -56,7 +56,7 @@
         nixpkgs.follows = "nixpkgs";
         flake-compat.follows = "";
         pre-commit.follows = "";
-        flake-utils.follows = "lanzaboote/flake-utils";
+        flake-utils.follows = "nixos-wsl/flake-utils";
       };
     };
 
@@ -66,7 +66,7 @@
       url = "sourcehut:~rycee/nur-expressions?dir=pkgs/firefox-addons";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "lanzaboote/flake-utils";
+        flake-utils.follows = "nixos-wsl/flake-utils";
       };
     };
 
@@ -110,7 +110,6 @@
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-compat.follows = "";
-        flake-utils.follows = "lanzaboote/flake-utils";
       };
     };
 
@@ -140,7 +139,7 @@
       url = "github:terranix/terranix";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "lanzaboote/flake-utils";
+        flake-utils.follows = "nixos-wsl/flake-utils";
         terranix-examples.follows = "";
         bats-support.follows = "";
         bats-assert.follows = "";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'agenix':
    'github:ryantm/agenix/de96bd907d5fbc3b14fc33ad37d1b9a3cb15edc6' (2024-07-09)
  → 'github:ryantm/agenix/3f1dae074a12feb7327b4bf43cbac0d124488bb7' (2024-07-30)
• Updated input 'agenix/systems':
    follows 'lanzaboote/flake-utils/systems'
  → follows 'nixos-wsl/flake-utils/systems'
• Updated input 'arkenfox':
    'github:dwarfmaster/arkenfox-nixos/35e803fa44abfd438c65b64ff2691f3f608cd2d3' (2024-06-17)
  → 'github:dwarfmaster/arkenfox-nixos/92c9a287b7b98198c3ba5cdfc90218402e49c4b3' (2024-07-23)
• Updated input 'arkenfox/flake-utils':
    follows 'lanzaboote/flake-utils'
  → follows 'nixos-wsl/flake-utils'
• Updated input 'catppuccin':
    'github:catppuccin/nix/d75d5803852fb0833767dc969a4581ac13204e22' (2024-07-08)
  → 'github:catppuccin/nix/19a0f144f0204a12a89243363efb6a493b8cfc83' (2024-08-03)
• Updated input 'firefox-addons':
    'sourcehut:~rycee/nur-expressions/f2c6c0e41d6c2c82524b9d104bcfd1750a426d1b?dir=pkgs/firefox-addons' (2024-07-01)
  → 'sourcehut:~rycee/nur-expressions/9cb92b3f92598f77aa8b95b54e5d72ad23745d64?dir=pkgs/firefox-addons' (2024-07-20)
• Updated input 'firefox-addons/flake-utils':
    follows 'lanzaboote/flake-utils'
  → follows 'nixos-wsl/flake-utils'
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
  → 'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
• Updated input 'getchvim':
    'github:getchoo/getchvim/b19001b3f3cf004c3e1fe3021580ed5368849502' (2024-07-17)
  → 'github:getchoo/getchvim/c120e1df24f1e44a6f7c8a9e16ac8269648501bd' (2024-08-03)
• Updated input 'home-manager':
    'github:nix-community/home-manager/afd2021bedff2de92dfce0e257a3d03ae65c603d' (2024-07-16)
  → 'github:nix-community/home-manager/afc892db74d65042031a093adb6010c4c3378422' (2024-08-02)
• Updated input 'lanzaboote':
    'github:nix-community/lanzaboote/0e6457c98547ec8866714d4222545e7e8c1ae429' (2024-07-01)
  → 'github:nix-community/lanzaboote/f5a3a7dff44d131807fc1a89fbd8576cd870334a' (2024-07-30)
• Updated input 'lanzaboote/crane':
    'github:ipetkov/crane/0095fd8ea00ae0a9e6014f39c375e40c2fbd3386' (2024-06-15)
  → 'github:ipetkov/crane/529c1a0b1f29f0d78fa3086b8f6a134c71ef3aaf' (2024-07-24)
• Removed input 'lanzaboote/flake-utils'
• Removed input 'lanzaboote/flake-utils/systems'
• Updated input 'lanzaboote/rust-overlay':
    'github:oxalica/rust-overlay/0043c3f92304823cc2c0a4354b0feaa61dfb4cd9' (2024-06-16)
  → 'github:oxalica/rust-overlay/a6fbda5d9a14fb5f7c69b8489d24afeb349c7bb4' (2024-07-29)
• Removed input 'lanzaboote/rust-overlay/flake-utils'
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/a3e4a7b8ffc08c7dc1973822a77ad432e1ec3dec' (2024-07-18)
  → 'github:LnL7/nix-darwin/f7142b8024d6b70c66fd646e1d099d3aa5bfec49' (2024-08-02)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/5fe5b0cdf1268112dc96319388819b46dc051ef4' (2024-07-14)
  → 'github:nix-community/nix-index-database/97ca0a0fca0391de835f57e44f369a283e37890f' (2024-08-04)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/8ebede998342477736e0d0acdcc13ddb166a335f' (2024-07-17)
  → 'github:nix-community/NixOS-WSL/f373ad59ae5866f0f98216bd5c71526b373450d2' (2024-07-29)
• Updated input 'nixos-wsl/flake-utils':
    follows 'lanzaboote/flake-utils'
  → 'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
• Added input 'nixos-wsl/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e' (2023-04-09)
• Updated input 'nixpkgs-tracker-bot':
    'github:getchoo/nixpkgs-tracker-bot/9b0e19d603e35083fa4ffefb1aedf13d8cfa8501' (2024-07-15)
  → 'github:getchoo/nixpkgs-tracker-bot/04af0af364a2c6ecabd2340a422049ec984357f4' (2024-08-03)
• Updated input 'openwrt-imagebuilder':
    'github:astro/nix-openwrt-imagebuilder/10a88c589e32e04dd717d5588b5ebacf83f25629' (2024-07-19)
  → 'github:astro/nix-openwrt-imagebuilder/02f547ee5f2e70488d643938903072590cb7fa86' (2024-08-04)
• Updated input 'teawiebot':
    'github:getchoo/teawiebot/5337f7eb3f8554b712a229de488937c01000db2d' (2024-07-13)
  → 'github:getchoo/teawiebot/372780546b508684839916e5ad54c9e90456a94f' (2024-07-27)
• Updated input 'terranix/flake-utils':
    follows 'lanzaboote/flake-utils'
  → follows 'nixos-wsl/flake-utils'
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/50104496fb55c9140501ea80d183f3223d13ff65' (2024-07-19)
  → 'github:numtide/treefmt-nix/768acdb06968e53aa1ee8de207fd955335c754b7' (2024-07-30)
