### PR TITLE
flake: pin nixpkgs to nixos-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -333,16 +333,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731265036,
-        "narHash": "sha256-e5I+glVZwQvLT6WIeMFi0Mk+N/jkYauZ31ir2NRZcf8=",
+        "lastModified": 1731139594,
+        "narHash": "sha256-IigrKK3vYRpUu+HEjPL/phrfh7Ox881er1UEsZvw9Q4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8aed22ecd71e5b67e5299efae8b9dc580dec711c",
+        "rev": "76612b17c0ce71689921ca12d9ffdc9c23ce40b2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable-small",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -254,7 +254,7 @@
     };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
 
     nix-darwin = {


### PR DESCRIPTION
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/8aed22ecd71e5b67e5299efae8b9dc580dec711c?narHash=sha256-e5I%2BglVZwQvLT6WIeMF
i0Mk%2BN/jkYauZ31ir2NRZcf8%3D' (2024-11-10)
  → 'github:NixOS/nixpkgs/76612b17c0ce71689921ca12d9ffdc9c23ce40b2?narHash=sha256-IigrKK3vYRpUu%2BHEjPL
/phrfh7Ox881er1UEsZvw9Q4%3D' (2024-11-09)
