### PR TITLE
Summer cleanup

### DIFF
--- a/.github/actions/install-nix-action/action.yml
+++ b/.github/actions/install-nix-action/action.yml
@@ -6,7 +6,7 @@ inputs:
   variant:
     description: "Nix implementation to install. Either Nix, Lix, or Dix"
     required: true
-    default: "Nix"
+    default: "Lix"
 
 runs:
   using: composite

--- a/flake.lock
+++ b/flake.lock
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780679734,
-        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
+        "lastModified": 1780943742,
+        "narHash": "sha256-01bTMR9ZPG+uxPaZBeOwagg5uxIaFYs2/3YIrOX+bCA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
+        "rev": "df39142474950e42d5fc3bf2fef9d6c62abbe8d7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -355,15 +355,15 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1780815147,
-        "narHash": "sha256-2+Vg1gKzP1QuHt3dZpb91PWSJVjZGD5MDhihTtav2lw=",
-        "rev": "9a681e663d65ff3b0c636df6c7cfbad31e1ed311",
+        "lastModified": 1780907025,
+        "narHash": "sha256-LJRbG2luUgX8uan0IMP7eNn4SZtA35smjLYWJZgdVh0=",
+        "rev": "b1d735948e5ca778ca50a881be98db8333372972",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/25.11-small/nixos-25.11.11972.9a681e663d65/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/26.05-small/nixos-26.05.1552.b1d735948e5c/nixexprs.tar.xz?lastModified=1780907025&rev=b1d735948e5ca778ca50a881be98db8333372972"
       },
       "original": {
         "type": "tarball",
-        "url": "https://channels.nixos.org/nixos-25.11-small/nixexprs.tar.xz"
+        "url": "https://channels.nixos.org/nixos-26.05-small/nixexprs.tar.xz"
       }
     },
     "nixpkgs-tracker-bot": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
 
   inputs = {
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
-    nixpkgs-stable.url = "https://channels.nixos.org/nixos-25.11-small/nixexprs.tar.xz";
+    nixpkgs-stable.url = "https://channels.nixos.org/nixos-26.05-small/nixexprs.tar.xz";
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";

--- a/modules/nixos/mixins/budgie.nix
+++ b/modules/nixos/mixins/budgie.nix
@@ -25,7 +25,7 @@
         ];
       };
 
-      services.xserver.desktopManager.budgie = {
+      services.desktopManager.budgie = {
         # Make sure we actually use the themes below
         extraGSettingsOverrides = ''
           [org.gnome.desktop.interface:Budgie]
@@ -36,7 +36,7 @@
       };
     }
 
-    (lib.mkIf config.services.xserver.desktopManager.budgie.enable {
+    (lib.mkIf config.services.desktopManager.budgie.enable {
       environment.systemPackages = with pkgs; [
         materia-theme
         papirus-icon-theme

--- a/modules/nixos/mixins/kanidm.nix
+++ b/modules/nixos/mixins/kanidm.nix
@@ -3,7 +3,7 @@
 let
   cfg = config.services.kanidm;
 
-  inherit (cfg.serverSettings) domain;
+  inherit (cfg.server.settings) domain;
   certDirectory = config.security.acme.certs.${domain}.directory;
 in
 
@@ -11,11 +11,11 @@ in
   config = lib.mkMerge [
     {
       services.kanidm = {
-        clientSettings = {
-          uri = lib.mkDefault cfg.serverSettings.origin;
+        client.settings = {
+          uri = lib.mkDefault cfg.server.settings.origin;
         };
 
-        serverSettings = {
+        server.settings = {
           tls_chain = certDirectory + "/fullchain.pem";
           tls_key = certDirectory + "/key.pem";
           origin = lib.mkDefault ("https://" + domain);
@@ -27,9 +27,9 @@ in
       };
     }
 
-    (lib.mkIf cfg.enableServer {
+    (lib.mkIf cfg.server.enable {
       borealis.reverseProxies.${domain} = {
-        locations."/".proxyPass = "https://" + cfg.serverSettings.bindaddress;
+        locations."/".proxyPass = "https://" + cfg.server.settings.bindaddress;
       };
 
       security.acme.certs.${domain} = {

--- a/modules/nixos/mixins/plasma.nix
+++ b/modules/nixos/mixins/plasma.nix
@@ -16,10 +16,6 @@
           plasma-browser-integration
         ];
       };
-
-      services.displayManager.sddm = {
-        wayland.enable = true;
-      };
     }
 
     (lib.mkIf config.services.desktopManager.plasma6.enable {
@@ -34,7 +30,7 @@
         ];
       };
 
-      services.displayManager.sddm = {
+      services.displayManager.plasma-login-manager = {
         enable = lib.mkDefault true;
       };
     })

--- a/modules/nixos/mixins/plasma.nix
+++ b/modules/nixos/mixins/plasma.nix
@@ -14,7 +14,12 @@
           khelpcenter
           konsole
           plasma-browser-integration
+          kwin-x11
         ];
+      };
+
+      services.desktopManager.plasma6 = {
+        enableQt5Integration = lib.mkDefault false;
       };
     }
 

--- a/modules/nixos/mixins/resolved.nix
+++ b/modules/nixos/mixins/resolved.nix
@@ -5,7 +5,9 @@
     {
       services.resolved = {
         enable = lib.mkDefault true;
-        dnsovertls = "true";
+        settings = {
+          Resolve.DNSOverTLS = "true";
+        };
       };
     }
 

--- a/systems/atlas/kanidm.nix
+++ b/systems/atlas/kanidm.nix
@@ -7,7 +7,7 @@
 
 let
   cfg = config.services.kanidm;
-  oauth2Domain = "https://" + cfg.serverSettings.domain;
+  oauth2Domain = "https://" + cfg.server.settings.domain;
 in
 
 {
@@ -18,11 +18,14 @@ in
   services = {
     kanidm = {
       package = pkgs.kanidm_1_10;
-      enableClient = true;
-      enableServer = true;
+      client.enable = true;
 
-      serverSettings = {
-        domain = "auth." + config.networking.domain;
+      server = {
+        enable = true;
+
+        settings = {
+          domain = "auth." + config.networking.domain;
+        };
       };
     };
 

--- a/systems/glados/default.nix
+++ b/systems/glados/default.nix
@@ -34,6 +34,11 @@
     package = config.boot.kernelPackages.nvidiaPackages.latest;
   };
 
+  home-manager.users.seth = {
+    # TODO: Move to $XDG_CONFIG_HOME
+    programs.firefox.configPath = ".mozilla/firefox";
+  };
+
   networking = {
     hostName = "glados";
     networkmanager.enable = true;

--- a/systems/glados/default.nix
+++ b/systems/glados/default.nix
@@ -67,7 +67,7 @@
   };
 
   services = {
-    desktopManager.gnome.enable = true;
+    desktopManager.plasma6.enable = true;
 
     flatpak.enable = true;
     fstrim.enable = true;

--- a/users/seth/mixins/budgie.nix
+++ b/users/seth/mixins/budgie.nix
@@ -1,7 +1,7 @@
 { lib, osConfig, ... }:
 
 let
-  enable = osConfig.services.xserver.desktopManager.budgie.enable or false;
+  enable = osConfig.services.desktopManager.budgie.enable or false;
 in
 
 {

--- a/users/seth/mixins/catppuccin.nix
+++ b/users/seth/mixins/catppuccin.nix
@@ -6,6 +6,8 @@
   ];
 
   catppuccin = {
+    autoEnable = true;
+
     accent = "mauve";
     flavor = "mocha";
 

--- a/users/seth/mixins/ssh.nix
+++ b/users/seth/mixins/ssh.nix
@@ -39,41 +39,37 @@ in
 
         enableDefaultConfig = false;
 
-        matchBlocks =
+        settings =
           let
             sshDir = "${config.home.homeDirectory}/.ssh";
           in
           {
             # git forges
             "codeberg.org" = {
-              identityFile = "${sshDir}/codeberg";
-              user = "git";
-            };
-
-            "github.com" = {
-              identityFile = "${sshDir}/github";
-              user = "git";
+              Hostname = "codeberg.org";
+              User = "git";
+              IdentityFile = "${sshDir}/codeberg";
             };
 
             # linux packaging
             "aur.archlinux.org" = {
-              identityFile = "${sshDir}/aur";
-              user = "aur";
+              Hostname = "aur.archlinux.org";
+              User = "aur";
+              IdentityFile = "${sshDir}/aur";
             };
 
             "pagure.io" = {
-              identityFile = "${sshDir}/copr";
-              user = "git";
+              Hostname = "pagure.io";
+              User = "git";
+              IdentityFile = "${sshDir}/copr";
             };
 
             # macstadium m1
             "mini.scrumplex.net" = {
-              identityFile = "${sshDir}/macstadium";
-              user = "bob-the-builder";
+              Hostname = "mini.scrumplex.net";
+              User = "bob-the-builder";
+              IdentityFile = "${sshDir}/macstadium";
             };
-
-            # servers
-            "atlas".user = "atlas";
           };
       };
     }


### PR DESCRIPTION
- **flake: update nixpkgs-stable to 26.05**
- **ci: use lix**
- **nixos/plasma: use plm**
- **nixos/plasma: remove x11 & qt5**
- **glados: gnome -> plasma**
- **seth/catppuccin: use new `autoEnable`**
- **nixos/budgie: mv services{.xserver,}.desktopManager.budgie**
- **atlas: mv services.kanidm.{enableServer,server.enable}**
- **seth/ssh: `matchBlocks` -> `settings`**
- **nixos/resolved: `dnsovertls` -> `settings.Resolve.DNSOverTLS`**
- **glados: set firefox config path for seth**
- **flake: update home-manager**
